### PR TITLE
Allow Definition of Deployment UpdateStrategy

### DIFF
--- a/charts/mediawiki/templates/deployment.yaml
+++ b/charts/mediawiki/templates/deployment.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "mediawiki.selectorLabels" . | nindent 6 }}
+  strategy: {{- .Values.updateStrategy | toYaml | nindent 4 }}
   template:
     metadata:
       annotations:

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -3,6 +3,8 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
+updateStrategy:
+  type: RollingUpdate
 
 nginxImage:
   repository: docker.io/library/nginx


### PR DESCRIPTION
Allows the configuration of the Deployment Update Strategy. Default is "RollingUpdate".

Sometimes it is necessary to have UpdateStrategy "Recreate" to prevent mounting conflicts for Persistent Volumes.