### PR TITLE
mediawiki: extraVolumeMounts for nginx container

### DIFF
--- a/charts/mediawiki/templates/deployment.yaml
+++ b/charts/mediawiki/templates/deployment.yaml
@@ -136,6 +136,9 @@ spec:
               subPath: 'types.conf'
               mountPath: /etc/nginx/conf.d/types.conf
               readOnly: true
+            {{- with .Values.nginx.extraVolumeMounts }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
         {{- if .Values.exporter.enabled }}
         - name: exporter
           securityContext:

--- a/charts/mediawiki/values.yaml
+++ b/charts/mediawiki/values.yaml
@@ -188,3 +188,6 @@ mediawiki:
     content: null
   extraVolumeMounts: []
   probesEnabled: true
+
+nginx:
+  extraVolumeMounts: []


### PR DESCRIPTION
Currently extraVolumeMounts is only supported for the mediawiki container but not for nginx.
I would like to extend the nginx.conf and therefore need to mount additional config-files in mount paths such as:

- /etc/nginx/conf.d/ratelimit.conf (for http-section)
- /default-server/botblock.conf (for server section)
