### PR TITLE
Fix: Changes default terminationMessagePath

### DIFF
--- a/charts/nvme-exporter/Chart.yaml
+++ b/charts/nvme-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvme-exporter
 description: A Helm chart for th nvme-exporter
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "latest"

--- a/charts/nvme-exporter/templates/daemonset.yaml
+++ b/charts/nvme-exporter/templates/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          terminationMessagePath: /tmp/termination-log
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:


### PR DESCRIPTION
Fix DaemonSet crash-loop on read-only /dev mount

The container bind-mounts host /dev read-only, but Kubernetes' default
terminationMessagePath (/dev/termination-log) makes runc try to create a
mountpoint inside that read-only path, failing container init with
"read-only file system".

Set terminationMessagePath to /tmp/termination-log (writable rootfs) so the
device mount can stay read-only.

Error message:

```
Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/var/lib/k0s/kubelet/pods/f420d0ab-f647-4c3d-9b58-2bfd45ad029b/containers/nvme-exporter/5e47c677" to rootfs at "/dev/termination-log": create mountpoint for /dev/termination-log mount: make mountpoint "/dev/termination-log": read-only file system: unknown
```